### PR TITLE
Removed webkit warning

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,6 @@
 		 id="P2y" class="param">1</span></span>)</code></a>
 		<button id="save">Save</button>
 	</h1>
-	<p><strong>This curve contains values out of range.</strong> But fear not young padawan! Just use <code>a fallback</code> as well for Webkit until the <a href="https://bugs.webkit.org/show_bug.cgi?id=45761">bug #45761</a> fix propagates to Safari.</p>
 </header>
 
 <div class="coordinate-plane">

--- a/interaction.js
+++ b/interaction.js
@@ -406,26 +406,6 @@ function update() {
 	for(var i=params.length; i--;) {
 		params[i].textContent = prettyOffsets[i]; 
 	}
-	
-	// Show webkit-friendly version, if needed
-	var webkitWarning = $('header > p');
-	
-	if (!bezier.inRange) {
-		var webkitBezier = bezier.clipped;
-		
-		webkitWarning.style.maxHeight = '3em';
-		$('a', webkitWarning).tabIndex = '0';
-		
-		$('code', webkitWarning).textContent = webkitBezier;
-		
-		if (prefix === '-webkit-') {
-			webkitBezier.applyStyle(current);
-		}
-	}
-	else {
-		webkitWarning.style.maxHeight = '';
-		$('a', webkitWarning).tabIndex = '-1';
-	}
 }
 
 // For actions that can wait


### PR DESCRIPTION
This referred to a bug (#45761) that was resolved fixed on 2011-09-28; it is no longer worth noting with such presence in 2018 and beyond.

Resolves #15