### PR TITLE
Fix ungrabbable point

### DIFF
--- a/style.css
+++ b/style.css
@@ -313,6 +313,7 @@ header > p {
 
 #P0, #P3 {
 	background: white;
+	pointer-events: none;
 }
 
 #P1, #P2 {


### PR DESCRIPTION
I accidentally placed one of the bezier points directly behind the point at the end of the line (see: https://cubic-bezier.com/#0,1,1,1), and I couldn't grab the node again from under the other point! Small change to remove all pointer events from `#P0` and `#P3` so they're "transparent" to the mouse.

Thanks for the great tool btw