### PR TITLE
Overwrite inline style for position

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,9 +88,6 @@
 <script src="cubic-bezier.js"></script>
 <script src="interaction.js"></script>
 
-<a href="https://twitter.com/share" class="twitter-share-button" data-count="vertical" data-via="LeaVerou" data-text="A better tool for generating cubic-bezier() easing functions!">Tweet</a>
-<script src="https://platform.twitter.com/widgets.js"></script>
-
 <script>_gaq = [['_setAccount', 'UA-25106441-3'], ['_trackPageview']];</script>
 <script src="https://www.google-analytics.com/ga.js" async></script>
 

--- a/style.css
+++ b/style.css
@@ -565,7 +565,7 @@ body > footer {
 	}
 
 .twitter-share-button {
-	position: fixed;
+	position: fixed !important;
 	top: 10px;
 	right: 10px;
 }

--- a/style.css
+++ b/style.css
@@ -564,12 +564,6 @@ body > footer {
 		background: #ddd;
 	}
 
-.twitter-share-button {
-	position: fixed !important;
-	top: 10px;
-	right: 10px;
-}
-
 @media (min-width: 1330px) {
 	#preview {
 		float: left;


### PR DESCRIPTION
I'll create a series of PRs that slowly introduce layout and responsiveness changes in small batches (usually bigger than this one but as small as possible).

About this change; I'm going to take a wild guess and say you're not a huge fan of `!important`; I understand, neither am I. This change is introduced because the script than injects this button sets an inline style of `position: static` on the element and so it overrides the `position: fixed` in this stylesheet. This `!important` overwrites the inline style, causing the button to go in the top right corner, as intended, rather than floating around somewhere at the bottom.