### PR TITLE
Patching up some of the remaining margins and paddings

### DIFF
--- a/style.css
+++ b/style.css
@@ -50,7 +50,7 @@ body {
 		'curve . .' auto / 300px 480px 1fr;
 	gap: 2rem;
 	position: relative;
-	margin: 1em 5% 0;
+	margin: 1em max(3rem, 5%) 0;
 	background: white;
 	font-family: 'Hiragino Kaku Gothic Pro', 'Segoe UI', 'Apple Gothic', Tahoma, 'Helvetica Neue', sans-serif;
 	line-height: 1.4;
@@ -371,14 +371,7 @@ section {}
 #preview {
 	grid-area: preview;
 	position: relative;
-	padding-right: 80px;
 }
-
-	#preview::after {
-		content: "";
-		display: block;
-		clear: both;
-	}
 
 	#preview > canvas {
 		display: block;
@@ -395,6 +388,7 @@ section {}
 
 	#preview > .move {
 		left: 100%;
+		transform: translateX(-100%);
 	}
 
 #library {


### PR DESCRIPTION
So here's the rest of the paddings and margins - not much at all, really. I fixed the left and right margins on the body so that things don't start to overlap the footer (see screenshots below). I also removed a right padding that was intended to work around the fact that probably at the time of writing this code `calc` didn't exist - instead of `calc` though, I used a `transform` so things don't rely on the size of the elements.

at an 800px wide screen (top is before, bottom is after. Note the footer on the left; this effect becomes worse the narrower the screen):

![image](https://user-images.githubusercontent.com/41021050/147869621-8ff1195c-fe67-44c3-8332-3ded335a4972.png)
![image](https://user-images.githubusercontent.com/41021050/147869623-90e73e95-4c93-4bb5-9cde-67dcfef58652.png)
