### PR TITLE
Added a few media queries to improve usability on narrow screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
 
 <meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1.0" />
 <title>cubic-bezier.com</title>
 <link href="style.css" rel="stylesheet" />
 <link rel="shortcut icon"  type="image/png" href="about:blank" />

--- a/style.css
+++ b/style.css
@@ -573,24 +573,6 @@ body > footer {
 @media (max-width: 850px){
 	body {
 		grid-template:
-			'header' auto
-			'curve' auto
-			'preview' auto
-			'library' auto / auto;
-	}
-
-	h1 > a {
-		font-size: 0.8em;
-	}
-
-	#copybuttons {
-		margin-left: auto;
-	}
-}
-
-@media (max-width: 768px){
-	body {
-		grid-template:
 			'footer' auto
 			'header' auto
 			'curve' auto
@@ -610,6 +592,10 @@ body > footer {
 	h1 > a {
 		font-size: 0.8em;
 		width: 100%;
+	}
+
+	#copybuttons {
+		margin-left: auto;
 	}
 }
 

--- a/style.css
+++ b/style.css
@@ -69,6 +69,7 @@ a:hover {
 }
 
 	h1 > a {
+		font-size: clamp(1.2rem, 2vw + .75rem, 2.5rem);
 		white-space: nowrap;
 		color: inherit;
 		text-decoration: none;
@@ -513,15 +514,10 @@ section {}
 
 body > footer {
 	grid-area: footer;
-	position: fixed;
-	top: 0;
-	right: 100%;
-	padding: .5em 1em;
-	white-space: nowrap;
+	padding: .5em 0;
+	max-width: 100%;
 	font-size: 120%;
 	color: rgba(0, 0, 0, .1);
-	transform: rotate(-90deg);
-	transform-origin: top right;
 	box-sizing: border-box;
 }
 
@@ -544,18 +540,18 @@ body > footer {
 @media (max-width: 1330px){
 	body {
 		grid-template:
-			'curve header' auto
-			'curve preview' auto
-			'curve library' auto / 300px 1fr;
+			'curve header'
+			'curve preview'
+			'curve library' / 300px 1fr;
 	}
 }
 
 @media (max-width: 1000px){
 	body {
 		grid-template:
-			'header header' auto
-			'curve preview' auto
-			'curve library' auto / 300px 1fr;
+			'header header'
+			'curve preview'
+			'curve library' / 300px 1fr;
 	}
 
 	header {
@@ -573,24 +569,15 @@ body > footer {
 @media (max-width: 850px){
 	body {
 		grid-template:
-			'footer' auto
-			'header' auto
-			'curve' auto
-			'preview' auto
-			'library' auto / auto;
+			'footer'
+			'header'
+			'curve'
+			'preview'
+			'library';
 		padding: 0 5% 1em;
 	}
 
-	body > footer {
-		padding: .5em 0;
-		position: static;
-		max-width: 100%;
-		transform: none;
-		white-space: normal;
-	}
-
 	h1 > a {
-		font-size: 0.8em;
 		width: 100%;
 	}
 
@@ -599,16 +586,19 @@ body > footer {
 	}
 }
 
-@media (max-width: 600px){
-	h1 > a {
-		font-size: 0.7em;
-		letter-spacing: -.05ch;
+@media not all and (max-width: 850px){
+	body > footer {
+		position: fixed;
+		top: 1em;
+		right: 100%;
+		transform: rotate(-90deg);
+		transform-origin: top right;
+		white-space: nowrap;
 	}
 }
 
-@media (max-width: 450px){
+@media (max-width: 600px){
 	h1 > a {
-		font-size: 0.6em;
 		letter-spacing: -.05ch;
 	}
 }

--- a/style.css
+++ b/style.css
@@ -50,7 +50,7 @@ body {
 		'curve . .' auto / 300px 480px 1fr;
 	gap: 2rem;
 	position: relative;
-	margin: 1em max(3rem, 5%) 0;
+	padding: 1em max(3rem, 5%);
 	background: white;
 	font-family: 'Hiragino Kaku Gothic Pro', 'Segoe UI', 'Apple Gothic', Tahoma, 'Helvetica Neue', sans-serif;
 	line-height: 1.4;
@@ -97,7 +97,6 @@ button:focus, .button:focus {
 #copybuttons {
 	display: inline-flex;
 	vertical-align: middle;
-	width: 85px;
 	position: relative;
 }
 
@@ -232,6 +231,7 @@ header {
 
 #curve-display {
 	grid-area: curve;
+	justify-self: center;
 }
 
 .coordinate-plane {
@@ -512,6 +512,7 @@ section {}
 	}
 
 body > footer {
+	grid-area: footer;
 	position: fixed;
 	top: 0;
 	right: 100%;
@@ -521,6 +522,7 @@ body > footer {
 	color: rgba(0, 0, 0, .1);
 	transform: rotate(-90deg);
 	transform-origin: top right;
+	box-sizing: border-box;
 }
 
 	body > footer > a {
@@ -539,13 +541,89 @@ body > footer {
 		background: #ddd;
 	}
 
-
 @media (max-width: 1330px){
 	body {
 		grid-template:
 			'curve header' auto
 			'curve preview' auto
 			'curve library' auto / 300px 1fr;
+	}
+}
+
+@media (max-width: 1000px){
+	body {
+		grid-template:
+			'header header' auto
+			'curve preview' auto
+			'curve library' auto / 300px 1fr;
+	}
+
+	header {
+		text-align: center;
+	}
+
+	header > h1 {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: center;
+		align-items: center;
+	}
+}
+
+@media (max-width: 850px){
+	body {
+		grid-template:
+			'header' auto
+			'curve' auto
+			'preview' auto
+			'library' auto / auto;
+	}
+
+	h1 > a {
+		font-size: 0.8em;
+	}
+
+	#copybuttons {
+		margin-left: auto;
+	}
+}
+
+@media (max-width: 768px){
+	body {
+		grid-template:
+			'footer' auto
+			'header' auto
+			'curve' auto
+			'preview' auto
+			'library' auto / auto;
+		padding: 0 5% 1em;
+	}
+
+	body > footer {
+		padding: .5em 0;
+		position: static;
+		max-width: 100%;
+		transform: none;
+		white-space: normal;
+	}
+
+	h1 > a {
+		font-size: 0.8em;
+		width: 100%;
+	}
+}
+
+@media (max-width: 600px){
+	h1 > a {
+		font-size: 0.7em;
+		letter-spacing: -.05ch;
+	}
+}
+
+@media (max-width: 450px){
+	h1 > a {
+		font-size: 0.6em;
+		letter-spacing: -.05ch;
 	}
 }
 


### PR DESCRIPTION
I added 4 media queries at different breakpoints to improve usability on a wider variety of screens. Here's a gif of the screen being resized:

![it_works](https://user-images.githubusercontent.com/41021050/147955537-6c3d56d3-7f2a-4e5e-9fcd-1a1c70dcbbc9.gif)

I admit, it doesn't look super great on semi-narrow screens (there's a lot of empty space on either side of the curve editor) but at least the preview and library are accessible by just scrolling down. I also decrease the `font-size` (and changed the `letter-spacing`) of the actual cubic bezier so it fits on the screen. The other option is breaking the text somewhere, but that looks off. Lastly, I also want to mention I moved the footer to the top of the page on narrower screens. That's not a very common place for a footer, but I figured it's not intrusive and still keeps your info right there on the initial page view.

